### PR TITLE
Support BUILD_SHARED_LIBS global option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(
 include("CeptonCommon")
 
 cmake_policy(SET CMP0077 NEW)
-option(BUILD_SHARED_LIBS "Use shared cepton sdk libraries." ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 include(CMakeDependentOption)
 cmake_dependent_option(CEPTON_SDK_USE_STATIC "Use static cepton sdk libraries." OFF BUILD_SHARED_LIBS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ project(
 
 include("CeptonCommon")
 
-create_option(BOOL CEPTON_SDK_USE_STATIC FALSE
-              "Use static cepton sdk libraries.")
+cmake_policy(SET CMP0077 NEW)
+option(BUILD_SHARED_LIBS "Use shared cepton sdk libraries." ON)
+include(CMakeDependentOption)
+cmake_dependent_option(CEPTON_SDK_USE_STATIC "Use static cepton sdk libraries." OFF BUILD_SHARED_LIBS ON)
 
 if(NOT TARGET cepton_sdk::cepton_sdk)
   if(CEPTON_SDK_USE_STATIC)


### PR DESCRIPTION
Adds support for the `BUILD_SHARED_LIBS` flag while maintaining the functionality of the `CEPTON_SDK_USE_STATIC` option for backwards compatibility. 

Note on line 19: `cmake_policy(SET CMP0077 NEW)` is necessary in versions of CMake <=3.12. If the minimum CMake version were increased to 3.13 or higher this line could be removed.